### PR TITLE
Flatten configuration to a dictionary that uses the "dot notation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,18 @@ const SMConfig = require('smconfig')
 
 The module exports a class named `SMConfig`.
 
-### Constructor: SMConfig(config, env, envVarPrefix)
+### Constructor: SMConfig(config, env, options)
 
 ````js
-let config = new SMConfig(config, env, envVarPrefix)
+let config = new SMConfig(config, env, options)
 ````
+
+Parameters:
+- `config`: configuration object (read below for description)
+- `env`: when set, forces a specific environment
+- `options`: dictionary with advanced options:
+    - `options.envVarPrefix`: prefix for environmental variables (default: `APPSETTING_`)
+    - `options.flatten`: when true, configuration object is also flatened to "dot notation" (default: true)
 
 The constructor determines the environment, then loads the configuration for the environment and stores it in the object.
 
@@ -99,7 +106,7 @@ When using YAML, you can also use the following types that are not supported by 
 - Functions: `!!js/function 'function () {...}'`
 - Undefined: `!!js/undefined ''`
 
-Configuration can also be passed at runtime (and it can override what is defined in the application or in the config files) with environmental variables. These values are prefixed with **`envVarPrefix`**, which defaults to `APPSETTING_`; the prefix is then removed, the key is lowercased and converted to camelCase. For example:
+Configuration can also be passed at runtime (and it can override what is defined in the application or in the config files) with environmental variables. These values are prefixed with **`options.envVarPrefix`**, which defaults to `APPSETTING_`; the prefix is then removed, the key is lowercased and converted to camelCase. For example:
 
 ````sh
 # SMConfig will store 'Passw0rd' for the 'databaseConfiguration' key
@@ -110,11 +117,50 @@ $ APPSETTING_DATABASE_PASSWORD=Passw0rd node myapp.js
 $ CUSTOMPREFIX_DATABASE_PASSWORD=Passw0rd node myapp.js
 ````
 
+When **`options.flatten`** is true, as per default value, the configuration data is also "flattened" into a dictionary that uses "dot notation". For example, imagine the following configuration:
+
+````js
+console.log(config.all)
+
+// Output when
+// options.flatten: false
+{
+    "database": {
+        "host": "db.example.com",
+        "username": "admin",
+        "password": "Passw0rd",
+        "ports": [8000, 8001]
+    },
+    "otherkey": "otherval"
+}
+
+// Output when
+// options.flatten: true
+{
+    "database": {
+        "host": "db.example.com",
+        "credentials": {
+            "username": "admin",
+            "password": "Passw0rd"
+        },
+        "ports": [8000, 8001]
+    },
+    "database.host": "db.example.com",
+    "database.credentials.username": "admin",
+    "database.credentials.password": "Passw0rd",
+    "database.ports": [8000, 8001],
+    "otherkey": "otherval"
+}
+````
+
 ### SMConfig.get(key)
 
 ````js
 // config is an instance of SMConfig
 let databasePassword = config.get('databasePassword')
+
+// If options.flatten is true, you can also access "nested" keys
+let nested = config.get('database.credentials.password')
 ````
 
 Returns the value for the key passed as argument, reading from the configuration for the environment.

--- a/test/SMConfig.test.js
+++ b/test/SMConfig.test.js
@@ -58,6 +58,18 @@ describe('SMConfig.js', () => {
         }
 
         // Expected configuration for testenv1 and testenv2
+        let defaultExpect = {
+            foo: 'bar',
+            hello: 'world',
+            number: 6,
+            ary: [0, 1, 1, 2, 3, 5, 8, 13, 21],
+            obj: {
+                x: 1,
+                y: 2
+            },
+            'obj.x': 1,
+            'obj.y': 2
+        }
         let testenv1Expect = {
             foo: 'bar',
             hello: 'mondo',
@@ -66,6 +78,7 @@ describe('SMConfig.js', () => {
             obj: {
                 z: 3
             },
+            'obj.z': 3,
             add: 'me'
         }
         let testenv2Expect = {
@@ -77,6 +90,8 @@ describe('SMConfig.js', () => {
                 x: 1,
                 y: 2
             },
+            'obj.x': 1,
+            'obj.y': 2,
             first: 'last'
         }
 
@@ -117,6 +132,13 @@ describe('SMConfig.js', () => {
             // All ok
             let config = new SMConfig({default: {}})
             assert.ok(config)
+        })
+
+        it('Options parameter', () => {
+            // Options parameter is not a dictionary
+            assert.throws(() => {
+                new SMConfig({default: {}}, 'default', 'invalid')
+            })
         })
 
         it('Environment: fallback to default', () => {
@@ -196,6 +218,11 @@ describe('SMConfig.js', () => {
 
         it('Configuration: load default configuration', () => {
             let config = new SMConfig(params, 'nonexisting')
+            assert.deepStrictEqual(config.all, defaultExpect)
+        })
+
+        it('Configuration: do not flatten configuration', () => {
+            let config = new SMConfig(params, 'nonexisting', {flatten: false})
             assert.deepStrictEqual(config.all, params.default)
         })
 
@@ -229,12 +256,12 @@ describe('SMConfig.js', () => {
             process.env.SET_FOO = 'overwrite-2' // Overwrite
             process.env.SET_SOME_FLOAT = '19.91' // camelCase
 
-            let expect = SMHelper.cloneObject(params.default)
+            let expect = SMHelper.cloneObject(defaultExpect)
             expect.when = 'runtime-again'
             expect.foo = 'overwrite-2'
             expect.someFloat = 19.91
 
-            let config = new SMConfig(params, 'default', 'SET_')
+            let config = new SMConfig(params, 'default', {envVarPrefix: 'SET_'})
             assert.deepStrictEqual(config.all, expect)
         })
 
@@ -252,19 +279,19 @@ describe('SMConfig.js', () => {
 
         it('Configuration: load from JSON file', () => {
             // Use another prefix for env vars so the ones set before are ignored
-            let config = new SMConfig('test/resources/testconfig.json', 'testenv2', 'NOTHING_')
+            let config = new SMConfig('test/resources/testconfig.json', 'testenv2', {envVarPrefix: 'NOTHING_'})
             assert.deepStrictEqual(config.all, testenv2Expect)
         })
 
         it('Configuration: load from YAML file', () => {
             // Use another prefix for env vars so the ones set before are ignored
-            let config = new SMConfig('test/resources/testconfig.yaml', 'testenv2', 'NOTHING_')
+            let config = new SMConfig('test/resources/testconfig.yaml', 'testenv2', {envVarPrefix: 'NOTHING_'})
             assert.deepStrictEqual(config.all, testenv2Expect)
         })
 
         it('Configuration: load from Hjson file', () => {
             // Use another prefix for env vars so the ones set before are ignored
-            let config = new SMConfig('test/resources/testconfig.hjson', 'testenv2', 'NOTHING_')
+            let config = new SMConfig('test/resources/testconfig.hjson', 'testenv2', {envVarPrefix: 'NOTHING_'})
             assert.deepStrictEqual(config.all, testenv2Expect)
         })
     })
@@ -284,7 +311,7 @@ describe('SMConfig.js', () => {
 
         it('SMConfig.all should return all configuration options', () => {
             // Use another prefix for env vars so the ones set before are ignored
-            let config = new SMConfig({default: {a: 1}, myenv: {b: 2}}, 'myenv', 'NOTHING_')
+            let config = new SMConfig({default: {a: 1}, myenv: {b: 2}}, 'myenv', {envVarPrefix: 'NOTHING_'})
             assert.deepStrictEqual(config.all, {a: 1, b: 2})
         })
 
@@ -297,7 +324,7 @@ describe('SMConfig.js', () => {
 
         it('SMConfig.get should return value for configuration key', () => {
             // Use another prefix for env vars so the ones set before are ignored
-            let config = new SMConfig({default: {a: 1}, myenv: {b: 'ale', foo: ['bar']}}, 'myenv', 'NOTHING_')
+            let config = new SMConfig({default: {a: 1}, myenv: {b: 'ale', foo: ['bar']}}, 'myenv', {envVarPrefix: 'NOTHING_'})
             assert.deepStrictEqual(config.get('a'), 1)
             assert.deepStrictEqual(config.get('b'), 'ale')
             assert.deepStrictEqual(config.get('foo'), ['bar'])


### PR DESCRIPTION
Use [SMHelper.objectToDotNotation](https://github.com/EgoAleSum/SMHelper#smhelperobjecttodotnotation) to "flatten" the configuration data into a dictionary that uses the "dot notation" (in addition to preserving the original data). This makes it possible to access nested properties more easily with `config.get('key1.key2')`.

Because of this change, the third parameter in the constructor got changed to an `options` dictionary